### PR TITLE
feat: update `Provider` composition and improve on `Delay` consistency

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           args:            --strict
 
-  # build the library.
-  build:
-    name:                  Build
+  # test the library.
+  test:
+    name:                  Test
     needs:                 lint
     runs-on:               macos-latest
 
@@ -98,6 +98,21 @@ jobs:
           filters:         |
             src:
               - '**/*.swift'
-      - name:              Build
+      # test the library.
+      - name:              Test
         if:                steps.changes.outputs.src == 'true'
-        run:               swift build
+        run:               swift test --parallel --enable-test-discovery --enable-code-coverage
+      # check for coverage.
+      - name:              Coverage (Export)
+        if:                steps.changes.outputs.src == 'true'
+        run:               xcrun llvm-cov export -format="lcov" .build/debug/ComposableRequestPackageTests.xctest/Contents/MacOS/ComposableRequestPackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+        continue-on-error: true
+      # upload coverage.
+      - name:              Coverage (Upload)
+        if:                steps.changes.outputs.src == 'true'
+        uses:              codecov/codecov-action@v1.5.0
+        with:
+          override_pr:     ${{ github.event.number }}
+          override_commit: ${{ (github.event.pull_request_target || github.event.pull_request).head.sha }}
+        timeout-minutes:   1
+        continue-on-error: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           args:              --strict
 
-  # build the library.
-  build:
-    name:                    Build
+  # test the library.
+  test:
+    name:                    Test
     needs:                   lint
     runs-on:                 macos-latest
 
@@ -45,14 +45,26 @@ jobs:
           filters:           |
             src:
               - '**/*.swift'
-      - name:                Build
+      # test the library.
+      - name:                Test
         if:                  steps.changes.outputs.src == 'true'
-        run:                 swift build
+        run:                 swift test --parallel --enable-test-discovery --enable-code-coverage
+      # check for coverage.
+      - name:                Coverage (Export)
+        if:                  steps.changes.outputs.src == 'true'
+        run:                 xcrun llvm-cov export -format="lcov" .build/debug/ComposableRequestPackageTests.xctest/Contents/MacOS/ComposableRequestPackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+        continue-on-error:   true
+      # upload coverage.
+      - name:                Coverage (Upload)
+        if:                  steps.changes.outputs.src == 'true'
+        uses:                codecov/codecov-action@v1.5.0
+        timeout-minutes:     1
+        continue-on-error:   true
 
   # release a new version.
   release:
     name:                    Release
-    needs:                   build
+    needs:                   test
     runs-on:                 ubuntu-latest
 
     steps:

--- a/Sources/ComposableRequest/Providers/Concat/ConcatProvider.swift
+++ b/Sources/ComposableRequest/Providers/Concat/ConcatProvider.swift
@@ -20,6 +20,7 @@ public struct ConcatProvider<A: Provider, B: Provider>: Provider where A.Output 
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (Input) -> Output) {
         self.generator = generator
     }
@@ -27,6 +28,7 @@ public struct ConcatProvider<A: Provider, B: Provider>: Provider where A.Output 
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (A.Input, B.Input) -> B.Output) {
         self.generator = { input in .init { generator(input, $0) } }
     }

--- a/Sources/ComposableRequest/Providers/Concat/ConcatProvider3.swift
+++ b/Sources/ComposableRequest/Providers/Concat/ConcatProvider3.swift
@@ -21,6 +21,7 @@ where A.Output == B, B.Output == C {
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (Input) -> Output) {
         self.generator = generator
     }
@@ -28,6 +29,7 @@ where A.Output == B, B.Output == C {
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (A.Input, B.Input, C.Input) -> C.Output) {
         self.generator = { input in .init { generator(input, $0, $1) } }
     }

--- a/Sources/ComposableRequest/Providers/Concat/ConcatProvider4.swift
+++ b/Sources/ComposableRequest/Providers/Concat/ConcatProvider4.swift
@@ -21,6 +21,7 @@ where A.Output == B, B.Output == C, C.Output == D {
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (Input) -> Output) {
         self.generator = generator
     }
@@ -28,6 +29,7 @@ where A.Output == B, B.Output == C, C.Output == D {
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (A.Input, B.Input, C.Input, D.Input) -> D.Output) {
         self.generator = { input in .init { generator(input, $0, $1, $2) } }
     }

--- a/Sources/ComposableRequest/Providers/Concat/ConcatProvider5.swift
+++ b/Sources/ComposableRequest/Providers/Concat/ConcatProvider5.swift
@@ -25,6 +25,7 @@ where A.Output == B, B.Output == C, C.Output == D, D.Output == E {
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (Input) -> Output) {
         self.generator = generator
     }
@@ -32,6 +33,7 @@ where A.Output == B, B.Output == C, C.Output == D, D.Output == E {
     /// Init.
     ///
     /// - parameter generator: A valid generator.
+    @available(*, deprecated, message: "use concat `init` on nested `A` directly (removing on `6.0.0`)")
     public init(_ generator: @escaping (A.Input, B.Input, C.Input, D.Input, E.Input) -> E.Output) {
         self.generator = { input in .init { generator(input, $0, $1, $2, $3) } }
     }

--- a/Sources/ComposableRequest/Providers/Pager/PagerProviderInput.swift
+++ b/Sources/ComposableRequest/Providers/Pager/PagerProviderInput.swift
@@ -14,18 +14,28 @@ public struct PagerProviderInput<Offset> {
     /// The actual offset.
     public let offset: Offset
     /// The delay.
-    public let delay: TimeInterval
+    public let delay: (_ offset: Offset) -> Delay
 
     /// Init.
     ///
     /// - parameters:
     ///     - count: A valid `Int`.
     ///     - offset: A valid `Offset`.
-    ///     - delay: A valid `TimeInterval`.
-    public init(count: Int, offset: Offset, delay: TimeInterval) {
+    ///     - delay: A valid `Delay` generator.
+    public init(count: Int, offset: Offset, delay: @escaping (_ offset: Offset) -> Delay) {
         self.count = count
         self.offset = offset
         self.delay = delay
+    }
+
+    /// Init.
+    ///
+    /// - parameters:
+    ///     - count: A valid `Int`.
+    ///     - offset: A valid `Offset`.
+    ///     - delay: A valid `Delay`.
+    public init(count: Int, offset: Offset, delay: Delay) {
+        self.init(count: count, offset: offset) { _ in delay }
     }
 }
 

--- a/Sources/ComposableRequest/Providers/Pager/PagerProviderType.swift
+++ b/Sources/ComposableRequest/Providers/Pager/PagerProviderType.swift
@@ -19,10 +19,43 @@ public extension PagerProviderType {
     /// - parameters:
     ///     - count: A valid `Int`.
     ///     - offset: A valid `Offset`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay` generator.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, offset: Offset, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, offset: Offset, delay: @escaping (_ offset: Offset) -> Delay) -> Output {
         Self.generate(self, from: .init(count: count, offset: offset, delay: delay))
+    }
+
+    /// Set up pagination.
+    ///
+    /// - parameters:
+    ///     - count: A valid `Int`.
+    ///     - offset: A valid `Offset`.
+    ///     - delay: A valid `Delay`. Defaults to `0` seconds.
+    /// - returns: Some `Content`.
+    func pages(_ count: Int, offset: Offset, delay: Delay = .seconds(0)) -> Output {
+        pages(count, offset: offset) { _ in delay }
+    }
+
+    /// Set up pagination.
+    ///
+    /// - parameters:
+    ///     - count: A valid `Int`.
+    ///     - offset: A valid `Offset`.
+    ///     - delay: A valid `TimeInterval` range. The delay is randomized for every single page.
+    /// - returns: Some `Content`.
+    func pages(_ count: Int, offset: Offset, delay: ClosedRange<TimeInterval>) -> Output {
+        pages(count, offset: offset) { _ in .seconds(.random(in: delay)) }
+    }
+
+    /// Set up pagination.
+    ///
+    /// - parameters:
+    ///     - count: A valid `Int`.
+    ///     - offset: A valid `Offset`.
+    ///     - delay: A valid `TimeInterval` range. The delay is randomized for every single page.
+    /// - returns: Some `Content`.
+    func pages(_ count: Int, offset: Offset, delay: Range<TimeInterval>) -> Output {
+        pages(count, offset: offset) { _ in .seconds(.random(in: delay)) }
     }
 }
 
@@ -31,9 +64,9 @@ public extension PagerProviderType where Offset == Void {
     ///
     /// - parameters:
     ///     - count: A valid `Int`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay`. Defaults to `0` seconds.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, delay: Delay = .seconds(0)) -> Output {
         self.pages(count, offset: (), delay: delay)
     }
 }
@@ -43,9 +76,9 @@ public extension PagerProviderType where Offset: ComposableOptionalType {
     ///
     /// - parameters:
     ///     - count: A valid `Int`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay`. Defaults to `0` seconds.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, delay: Delay = .seconds(0)) -> Output {
         self.pages(count, offset: .composableNone, delay: delay)
     }
 }
@@ -57,9 +90,9 @@ public extension PagerProviderType where Offset: Ranked {
     ///     - count: A valid `Int`.
     ///     - offset: A valid `Offset`.
     ///     - rank: A valid `Rank`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay`. Defaults to `0` seconds.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, offset: Offset.Offset, rank: Offset.Rank, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, offset: Offset.Offset, rank: Offset.Rank, delay: Delay = .seconds(0)) -> Output {
         self.pages(count, offset: .init(offset: offset, rank: rank), delay: delay)
     }
 }
@@ -70,9 +103,9 @@ public extension PagerProviderType where Offset: Ranked, Offset.Offset: Composab
     /// - parameters:
     ///     - count: A valid `Int`.
     ///     - rank: A valid `Rank`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay`. Defaults to `0`.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, rank: Offset.Rank, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, rank: Offset.Rank, delay: Delay = .seconds(0)) -> Output {
         self.pages(count, offset: .init(offset: .composableNone, rank: rank), delay: delay)
     }
 }
@@ -83,9 +116,9 @@ public extension PagerProviderType where Offset: Ranked, Offset.Rank: Composable
     /// - parameters:
     ///     - count: A valid `Int`.
     ///     - offset: A valid `Offset`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay`. Defaults to `0` seconds.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, offset: Offset.Offset, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, offset: Offset.Offset, delay: Delay = .seconds(0)) -> Output {
         self.pages(count, offset: .init(offset: offset, rank: .composableNone), delay: delay)
     }
 }
@@ -96,9 +129,9 @@ where Offset: Ranked, Offset.Offset: ComposableOptionalType, Offset.Rank: Compos
     ///
     /// - parameters:
     ///     - count: A valid `Int`.
-    ///     - delay: A valid `TimeInterval`. Defaults to `0`.
+    ///     - delay: A valid `Delay`. Defaults to `0` seconds.
     /// - returns: Some `Content`.
-    func pages(_ count: Int, delay: TimeInterval = 0) -> Output {
+    func pages(_ count: Int, delay: Delay = .seconds(0)) -> Output {
         self.pages(count, offset: .init(offset: .composableNone, rank: .composableNone), delay: delay)
     }
 }

--- a/Sources/ComposableRequest/Providers/Provider+Alias.swift
+++ b/Sources/ComposableRequest/Providers/Provider+Alias.swift
@@ -10,15 +10,11 @@ import Foundation
 // swiftlint:disable line_length
 /// A `typealias` for a composition of `LockProvider`,
 /// `SessionProvider` and `PagerProvider`.
-public typealias LockSessionPagerProvider <Input, Offset, Output> = ConcatProvider3<LockProvider<Input, SessionProvider<PagerProvider <Offset, Output>>>,
-                                                                                    SessionProvider<PagerProvider<Offset, Output>>,
-                                                                                    PagerProvider<Offset, Output>>
+public typealias LockSessionPagerProvider <Input, Offset, Output> = LockProvider<Input, SessionProvider<PagerProvider <Offset, Output>>>
 
 /// A `typealias` for a composition of `LockProvider` and `SessionProvider`.
-public typealias LockSessionProvider <Input, Output> = ConcatProvider<LockProvider<Input, SessionProvider<Output>>,
-                                                                      SessionProvider<Output>>
+public typealias LockSessionProvider <Input, Output> = LockProvider<Input, SessionProvider<Output>>
 
 /// A `typealias` for a composition of `SessionProvider` and `PagerProvider`.
-public typealias SessionPagerProvider <Offset, Output> = ConcatProvider<SessionProvider<PagerProvider<Offset, Output>>,
-                                                                        PagerProvider<Offset, Output>>
+public typealias SessionPagerProvider <Offset, Output> = SessionProvider<PagerProvider<Offset, Output>>
 // swiftlint:enable line_length

--- a/Sources/ComposableRequest/Providers/Provider.swift
+++ b/Sources/ComposableRequest/Providers/Provider.swift
@@ -28,3 +28,45 @@ public protocol Provider {
     /// - returns: A valid `Output`.
     static func generate(_ provider: Self, from input: Input) -> Output
 }
+
+public extension Provider where Output: Provider {
+    /// Init.
+    ///
+    /// - parameter generator: A valid generator.
+    init(_ generator: @escaping (Input, Output.Input) -> Output.Output) {
+        self.init { input in .init { generator(input, $0) } }
+    }
+}
+
+public extension Provider where Output: Provider,
+                                Output.Output: Provider {
+    /// Init.
+    ///
+    /// - parameter generator: A valid generator.
+    init(_ generator: @escaping (Input, Output.Input, Output.Output.Input) -> Output.Output.Output) {
+        self.init { input in .init { generator(input, $0, $1) } }
+    }
+}
+
+public extension Provider where Output: Provider,
+                                Output.Output: Provider,
+                                Output.Output.Output: Provider {
+    /// Init.
+    ///
+    /// - parameter generator: A valid generator.
+    init(_ generator: @escaping (Input, Output.Input, Output.Output.Input, Output.Output.Output.Input) -> Output.Output.Output.Output) {
+        self.init { input in .init { generator(input, $0, $1, $2) } }
+    }
+}
+
+public extension Provider where Output: Provider,
+                                Output.Output: Provider,
+                                Output.Output.Output: Provider,
+                                Output.Output.Output.Output: Provider {
+    /// Init.
+    ///
+    /// - parameter generator: A valid generator.
+    init(_ generator: @escaping (Input, Output.Input, Output.Output.Input, Output.Output.Output.Input, Output.Output.Output.Output.Input) -> Output.Output.Output.Output.Output) {
+        self.init { input in .init { generator(input, $0, $1, $2, $3) } }
+    }
+}

--- a/Sources/ComposableRequest/Publishers/Pager/Pager+Delay.swift
+++ b/Sources/ComposableRequest/Publishers/Pager/Pager+Delay.swift
@@ -1,0 +1,11 @@
+//
+//  Pager+Delay.swift
+//  ComposableRequest
+//
+//  Created by Stefano Bertagno on 25/05/21.
+//
+
+import Foundation
+
+/// The associated delay type.
+public typealias Delay = RunLoop.SchedulerTimeType.Stride

--- a/Tests/ComposableRequestTests/ConcatProviderTests.swift
+++ b/Tests/ComposableRequestTests/ConcatProviderTests.swift
@@ -1,5 +1,5 @@
 //
-//  DeprecationsTests.swift
+//  ConcatProviderTests.swift
 //  ComposableRequestTests
 //
 //  Created by Stefano Bertagno on 25/05/21.
@@ -11,9 +11,7 @@ import XCTest
 @testable import ComposableRequest
 
 /// A `class` defining a series of tests on deprecated definitions.
-internal final class DeprecationsTests: XCTestCase {
-    // MARK: Removing starting with `6.0.0`
-
+internal final class ConcatProviderTests: XCTestCase {
     // swiftlint:disable line_length
     /// Test concat providers.
     func testConcatProviders() {

--- a/Tests/ComposableRequestTests/DeprecationsTests.swift
+++ b/Tests/ComposableRequestTests/DeprecationsTests.swift
@@ -1,0 +1,63 @@
+//
+//  DeprecationsTests.swift
+//  ComposableRequestTests
+//
+//  Created by Stefano Bertagno on 25/05/21.
+//
+
+import Combine
+import XCTest
+
+@testable import ComposableRequest
+
+/// A `class` defining a series of tests on deprecated definitions.
+internal final class DeprecationsTests: XCTestCase {
+    // MARK: Removing starting with `6.0.0`
+
+    // swiftlint:disable line_length
+    /// Test concat providers.
+    func testConcatProviders() {
+        typealias Lock = ConcatProvider<LockProvider<Int, LockProvider<Int, Int>>,
+                                        LockProvider<Int, Int>>
+        XCTAssertEqual(Lock { $0+$1 }.unlock(with: 1).unlock(with: 2), 3)
+
+        typealias Lock3 = ConcatProvider3<LockProvider<Int, LockProvider<Int, LockProvider<Int, Int>>>,
+                                          LockProvider<Int, LockProvider<Int, Int>>,
+                                          LockProvider<Int, Int>>
+        XCTAssertEqual(Lock3 { $0+$1+$2 }.unlock(with: 1).unlock(with: 2).unlock(with: 3), 6)
+
+        typealias Lock4 = ConcatProvider4 <LockProvider<Int, LockProvider<Int, LockProvider<Int, LockProvider<Int, Int>>>>,
+                                           LockProvider<Int, LockProvider<Int, LockProvider<Int, Int>>>,
+                                           LockProvider<Int, LockProvider<Int, Int>>,
+                                           LockProvider<Int, Int>>
+        XCTAssertEqual(Lock4 { $0+$1+$2+$3 }.unlock(with: 1).unlock(with: 2).unlock(with: 3).unlock(with: 4), 10)
+
+        typealias Lock5 = ConcatProvider5 <LockProvider<Int, LockProvider<Int, LockProvider<Int, LockProvider<Int, LockProvider<Int, Int>>>>>,
+                                           LockProvider<Int, LockProvider<Int, LockProvider<Int, LockProvider<Int, Int>>>>,
+                                           LockProvider<Int, LockProvider<Int, LockProvider<Int, Int>>>,
+                                           LockProvider<Int, LockProvider<Int, Int>>,
+                                           LockProvider<Int, Int>>
+        XCTAssertEqual(Lock5 { $0+$1+$2+$3+$4 }.unlock(with: 1).unlock(with: 2).unlock(with: 3).unlock(with: 4).unlock(with: 5), 15)
+
+        XCTAssertEqual(
+            Lock5 { one in
+                Lock4 { two in
+                    Lock3 { three in
+                        Lock { four in
+                            .init { five in
+                                one + two + three + four + five
+                            }
+                        }
+                    }
+                }
+            }
+            .unlock(with: 1)
+            .unlock(with: 2)
+            .unlock(with: 3)
+            .unlock(with: 4)
+            .unlock(with: 5),
+            15
+        )
+    }
+    // swiftlint:enable line_length
+}

--- a/Tests/ComposableRequestTests/ExtensionsTests.swift
+++ b/Tests/ComposableRequestTests/ExtensionsTests.swift
@@ -9,12 +9,14 @@
 import XCTest
 
 internal final class ExtensionsTests: XCTestCase {
-    /// Test `String` extensions.
-    func testString() {
-        XCTAssert("camel_cased".camelCased == "camelCased")
-        XCTAssert("snakeCased".snakeCased == "snake_cased")
-        XCTAssert("begin".beginningWithUppercase == "Begin")
-        XCTAssert("BEGIN".beginningWithLowercase == "bEGIN")
+    /// Test `ComposableOptionalType`.
+    func testComposableOptionalType() {
+        XCTAssert(Int?.none.composableIsNone == true)
+        XCTAssert(Int?.some(0).composableIsNone == false)
+        XCTAssert(Int?.none.composableFlatMap { $0 + 1 }.composableIsNone == true)
+        XCTAssert(Int?.some(0).composableFlatMap { $0 + 1 } == 1)
+        XCTAssert(Int?.some(0).composableOptional == 0)
+        XCTAssert(Int?.composableNone.composableIsNone)
     }
 
     /// Test `HTTPCookie` extensions..
@@ -29,5 +31,13 @@ internal final class ExtensionsTests: XCTestCase {
         let decoded = try JSONDecoder().decode(CodableHTTPCookie.self,
                                                from: JSONEncoder().encode(cookie))
         XCTAssert(decoded == cookie)
+    }
+
+    /// Test `String` extensions.
+    func testString() {
+        XCTAssert("camel_cased".camelCased == "camelCased")
+        XCTAssert("snakeCased".snakeCased == "snake_cased")
+        XCTAssert("begin".beginningWithUppercase == "Begin")
+        XCTAssert("BEGIN".beginningWithLowercase == "bEGIN")
     }
 }

--- a/Tests/ComposableRequestTests/ExtensionsTests.swift
+++ b/Tests/ComposableRequestTests/ExtensionsTests.swift
@@ -33,6 +33,13 @@ internal final class ExtensionsTests: XCTestCase {
         XCTAssert(decoded == cookie)
     }
 
+    /// Test reference.
+    func testReference() {
+        let atomic: Atomic<Int> = .init(1)
+        atomic.mutate { $0 = 2 }
+        XCTAssertEqual(atomic.value, 2)
+    }
+
     /// Test `String` extensions.
     func testString() {
         XCTAssert("camel_cased".camelCased == "camelCased")

--- a/Tests/ComposableRequestTests/PagerTests.swift
+++ b/Tests/ComposableRequestTests/PagerTests.swift
@@ -1,0 +1,78 @@
+//
+//  PagerTests.swift
+//  ComposableRequestTests
+//
+//  Created by Stefano Bertagno on 25/05/21.
+//
+
+import Foundation
+import XCTest
+
+@testable import ComposableRequest
+
+/// A `class` defining `Pager`-specific tests.
+internal class PagerTests: XCTestCase {
+    /// Test pager provders.
+    func testPagerProvider() {
+        let provider = PagerProvider<RankedOffset<Int, Int>, Int> {
+            $0.count+$0.offset.offset+$0.rank + Int($0.delay($0.offset).magnitude)
+        }
+        XCTAssertEqual(PagerProviderInput(count: 0, offset: 1, delay: 2).delay(0),
+                       PagerProviderInput(count: 0, offset: 1) { $0 }.delay(2))
+        XCTAssertEqual(RankedOffset(offset: 1, rank: 2), RankedOffset(offset: 1, rank: 3))
+
+        XCTAssertEqual(provider.pages(1, offset: .init(offset: 2, rank: 3)) { _ in .seconds(4) }, 10)
+        XCTAssertEqual(provider.pages(1, offset: .init(offset: 2, rank: 3)), 6)
+
+        let closedRange = provider.pages(1, offset: .init(offset: 2, rank: 3), delay: 4..<5)
+        XCTAssertGreaterThanOrEqual(closedRange, 10)
+        XCTAssertLessThan(closedRange, 11)
+
+        let openRange = provider.pages(1, offset: .init(offset: 2, rank: 3), delay: 4...5)
+        XCTAssertGreaterThanOrEqual(openRange, 10)
+        XCTAssertLessThanOrEqual(openRange, 11)
+
+        XCTAssertEqual(provider.pages(1, offset: .init(offset: 2, rank: 3), delay: 4), 10)
+    }
+
+    /// Test `Void`-input pager providers.
+    func testVoidInputPagerProvider() {
+        let provider = PagerProvider<Void, Int> { $0.count + Int($0.delay($0.offset).magnitude) }
+        XCTAssertEqual(provider.pages(1, delay: .seconds(2)), 3)
+    }
+
+    /// Test `ComposableOptionalType`-input pager providers.
+    func testComposableOptionalTypePagerProvider() {
+        let provider = PagerProvider<Int?, Int> { $0.count + Int($0.delay($0.offset).magnitude) + ($0.offset ?? 0) }
+        XCTAssertEqual(provider.pages(1, delay: .seconds(2)), 3)
+    }
+
+    /// Test `Ranked`-input pager providers.
+    func testRankedPagerProvider() {
+        let provider = PagerProvider<RankedOffset<Int, Int>, Int> {
+            $0.count+$0.offset.offset+$0.rank + Int($0.delay($0.offset).magnitude)
+        }
+        XCTAssertEqual(provider.pages(1, offset: 2, rank: 3, delay: .seconds(4)), 10)
+    }
+
+    /// Test optional-`Rank` `Ranked`-input pager providers.
+    func testRankedOptionalPagerProvider() {
+        let offset = PagerProvider<RankedOffset<Int?, Int>, Int> {
+            $0.count + ($0.offset.offset ?? 0)+$0.rank + Int($0.delay($0.offset).magnitude)
+        }
+        XCTAssertEqual(offset.pages(1, rank: 2, delay: .seconds(3)), 6)
+
+        let rank = PagerProvider<RankedOffset<Int, Int?>, Int> {
+            $0.count+$0.offset.offset + ($0.rank ?? 0) + Int($0.delay($0.offset).magnitude)
+        }
+        XCTAssertEqual(rank.pages(1, offset: 2, delay: .seconds(3)), 6)
+    }
+
+    /// Test optional `Ranked`-input pager providers.
+    func testOptionalRankedPagerProvider() {
+        let provider = PagerProvider<RankedOffset<Int?, Int?>, Int> {
+            $0.count + ($0.offset.offset ?? 0) + ($0.rank ?? 0) + Int($0.delay($0.offset).magnitude)
+        }
+        XCTAssertEqual(provider.pages(1, delay: .seconds(2)), 3)
+    }
+}

--- a/Tests/ComposableRequestTests/WrappersTests.swift
+++ b/Tests/ComposableRequestTests/WrappersTests.swift
@@ -47,7 +47,7 @@ internal final class WrappersTests: XCTestCase {
 
     /// Test `Wrapped`.
     func testWrapped() throws {
-        let array = Wrapped(wrapper: [["key": 2]])
+        let array = Wrapped(wrapper: [["key": 2]]).wrapped
         XCTAssert(array[0].dictionary() == ["key": 2])
         XCTAssert(try JSONDecoder().decode(Wrapped.self, from: JSONEncoder().encode(array))[0]
                     .dictionary() == ["key": 2])
@@ -73,6 +73,7 @@ internal final class WrappersTests: XCTestCase {
         XCTAssert(first?["bool"].bool() == true, "Bool is not `Bool`.")
         XCTAssert(first?.dictionary()?["double"]?.double() == 2.3, "`Double` is not `Double`.")
         XCTAssert(first?["url"].url() != nil, "`URL` is not `URL`.")
+        XCTAssert(value.wrapped == value)
         // check literals.
         response = .empty
         XCTAssert(response.description == "<null>")


### PR DESCRIPTION
* [`50953d7`](http://github.com/sbertix/ComposableRequest/commit/50953d7bf5ed5d4ece95cd40dd50a421f2d9b8ef) - feat(pager): conform to Combine-like custom `Delay`
* [`3249ba1`](http://github.com/sbertix/ComposableRequest/commit/3249ba171e4d3cbf834ebb095931d9a620386769) - feat(concat): add native composition in `Provider`
* [`54f756b`](http://github.com/sbertix/ComposableRequest/commit/54f756b8d391a30a95bad37f6f58d32954c7306e) - ci(actions): add back support for CodeCov coverage
* [`888de57`](http://github.com/sbertix/ComposableRequest/commit/888de5751dc0a015551551336e04a5af5c08af6c) - test: add new `XCTestCase`s