### PR TITLE
fix: support unwrapped `Instruction` in iteration

### DIFF
--- a/Sources/ComposableRequest/Providers/Lock/LockProviderType.swift
+++ b/Sources/ComposableRequest/Providers/Lock/LockProviderType.swift
@@ -19,3 +19,12 @@ public extension LockProviderType {
         Self.generate(self, from: key)
     }
 }
+
+public extension LockProviderType where Input == Void {
+    /// Unlock.
+    ///
+    /// - returns: Some `Content`.
+    func unlock() -> Output {
+        Self.generate(self, from: ())
+    }
+}


### PR DESCRIPTION
* [`19343f6`](http://github.com/sbertix/ComposableRequest/commit/19343f6ca99e85253b88b70607ba66a82c4ae57d) - fix: support unwrapped `Instruction` in iteration
* [`887ba6f`](http://github.com/sbertix/ComposableRequest/commit/887ba6fc8d6aa40c1192ec7c0533b03ba4f9f008) - test: improve on testing